### PR TITLE
Prevent images to be shown when hovered

### DIFF
--- a/release/main.css
+++ b/release/main.css
@@ -43,6 +43,6 @@
   margin: 0 0 1em;
 }
 
-#gallery a img:hover {
+#gallery a img.loaded:hover {
   opacity: 1;
 }


### PR DESCRIPTION
After this change, only loaded images are shown even if they are hovered