### PR TITLE
Port to Firefox.

### DIFF
--- a/release/manifest.json
+++ b/release/manifest.json
@@ -11,6 +11,5 @@
   "browser_action": {
     "default_popup": "popup.html"
   },
-  "background": {},
   "permissions": ["https://www.pixiv.net/"]
 }


### PR DESCRIPTION
I love illustration and Firefox, so I ported Ku-nya to Firefox!

Thanks to the WebExtensions API, real porting *effort* is almost nothing: ~3 min for searching how to make an extension and ~1 min for validating it on addons.mozilla.org (AMO).

What I actually did is to remove optional and unused `background` field in `manifest.json` since Firefox requires `page` field in it. I confirmed that the modified code runs on Firefox 61.0.1 and Chrome  67.0.3396.99 with Windows 10 x64.

It would be great if you could [publish it to AMO](https://developer.mozilla.org/ja/Add-ons/Distribution/Submitting_an_add-on). Otherwise, I will help.

Packaging:
```shell
$ yarn build
$ cd release
$ find . | xargs zip ../Ku-nya.zip
```

Screenshot:
![Ku-nya on Firefox](https://user-images.githubusercontent.com/167209/43045836-37a1ad8c-8dc0-11e8-88ce-9f1a4df5fd4e.png)
