### PR TITLE
Add CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,10 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10.7.0
+    working_directory: ~/app
+    steps:
+      - checkout
+      - run: yarn install
+      - run: yarn build


### PR DESCRIPTION
This adds an automatic builder configuration for CircleCI.

It'll be easier to check building, testing, linting, or publishing this product continuously.