### PR TITLE
check if 'extraHeaders' is supported

### DIFF
--- a/src/lib/requestModifier.ts
+++ b/src/lib/requestModifier.ts
@@ -1,6 +1,11 @@
 const refererValue = 'https://www.pixiv.net/'
 const refererTarget = 'https://i.pximg.net/*'
 
+let extraInfoSpec = ['requestHeaders', 'blocking']
+if (chrome.webRequest['OnBeforeSendHeadersOptions'].hasOwnProperty('EXTRA_HEADERS')) {
+  extraInfoSpec.push('extraHeaders')
+}
+
 /** Modifies request Referer HTTP header */
 chrome.webRequest.onBeforeSendHeaders.addListener(
   details => {
@@ -25,5 +30,5 @@ chrome.webRequest.onBeforeSendHeaders.addListener(
   {
     urls: [refererTarget],
   },
-  ['requestHeaders', 'extraHeaders', 'blocking'],
+  extraInfoSpec
 )


### PR DESCRIPTION
'extraHeaders' is not supported yet on stable releases of Chrome (71), therefore Ku-nya has been broken since https://github.com/tamanobi/Ku-nya/pull/38. This PR should fix it.

References:
https://github.com/tamanobi/Ku-nya/pull/38#issuecomment-447700361
https://groups.google.com/a/chromium.org/forum/#!topic/chromium-extensions/vYIaeezZwfQ