### PR TITLE
fix: make sure excluding tags are set correctly

### DIFF
--- a/src/lib/options.ts
+++ b/src/lib/options.ts
@@ -56,7 +56,7 @@ export const setExcludingTags = (tags: string[]) => {
     {
       method: 'setExcludingTags',
       params: {
-        excluding_tags: tags,
+        tags,
       },
     },
     () => {},


### PR DESCRIPTION
Fixed an issue that caused the value of the local storage to be `undefined` when trying to add the excluding tags setting.